### PR TITLE
WIP Renamed all `deferred` to `trickled`

### DIFF
--- a/core/object_data.cpp
+++ b/core/object_data.cpp
@@ -42,7 +42,7 @@ bool ObjectData::has_registered_process_functions() const {
 	return false;
 }
 
-bool ObjectData::can_deferred_sync() const {
+bool ObjectData::can_trickled_sync() const {
 	return collect_epoch_func.is_valid() && apply_epoch_func.is_valid();
 }
 

--- a/core/object_data.h
+++ b/core/object_data.h
@@ -69,7 +69,7 @@ public:
 	ObjectLocalId get_local_id() const;
 
 	bool has_registered_process_functions() const;
-	bool can_deferred_sync() const;
+	bool can_trickled_sync() const;
 
 	void set_controller(class NetworkedControllerBase *p_controller);
 	class NetworkedControllerBase *get_controller() const;

--- a/doc_classes/SceneSynchronizer.xml
+++ b/doc_classes/SceneSynchronizer.xml
@@ -35,7 +35,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_max_deferred_nodes_per_update" qualifiers="const">
+		<method name="get_max_trickled_nodes_per_update" qualifiers="const">
 			<return type="int" />
 			<description>
 			</description>
@@ -141,7 +141,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_max_deferred_nodes_per_update">
+		<method name="set_max_trickled_nodes_per_update">
 			<return type="void" />
 			<param index="0" name="rate" type="int" />
 			<description>
@@ -162,7 +162,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="setup_deferred_sync">
+		<method name="setup_trickled_sync">
 			<return type="void" />
 			<param index="0" name="node" type="Node" />
 			<param index="1" name="collect_epoch_func" type="Callable" />
@@ -195,7 +195,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="sync_group_get_deferred_update_rate" qualifiers="const">
+		<method name="sync_group_get_trickled_update_rate" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="node_id" type="int" />
 			<param index="1" name="group_id" type="int" />
@@ -216,7 +216,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="sync_group_set_deferred_update_rate">
+		<method name="sync_group_set_trickled_update_rate">
 			<return type="void" />
 			<param index="0" name="node_id" type="int" />
 			<param index="1" name="group_id" type="int" />

--- a/godot4/gd_scene_synchronizer.h
+++ b/godot4/gd_scene_synchronizer.h
@@ -41,8 +41,8 @@ public:
 	void _notification(int p_what);
 
 public: // ---------------------------------------------------------- Properties
-	void set_max_deferred_nodes_per_update(int p_rate);
-	int get_max_deferred_nodes_per_update() const;
+	void set_max_trickled_nodes_per_update(int p_rate);
+	int get_max_trickled_nodes_per_update() const;
 
 	void set_server_notify_state_interval(real_t p_interval);
 	real_t get_server_notify_state_interval() const;
@@ -115,10 +115,10 @@ public: // ---------------------------------------------------------------- APIs
 	uint64_t register_process(Node *p_node, ProcessPhase p_phase, const Callable &p_callable);
 	void unregister_process(Node *p_node, ProcessPhase p_phase, uint64_t p_handler);
 
-	/// Setup the deferred sync method for this specific node.
-	/// The deferred-sync is different from the realtime-sync because the data
+	/// Setup the trickled sync method for this specific node.
+	/// The trickled-sync is different from the realtime-sync because the data
 	/// is streamed and not simulated.
-	void setup_deferred_sync(Node *p_node, const Callable &p_collect_epoch_func, const Callable &p_apply_epoch_func);
+	void setup_trickled_sync(Node *p_node, const Callable &p_collect_epoch_func, const Callable &p_apply_epoch_func);
 
 	/// Creates a realtime sync group containing a list of nodes.
 	/// The Peers listening to this group will receive the updates only
@@ -131,18 +131,18 @@ public: // ---------------------------------------------------------------- APIs
 	void sync_group_remove_node_by_id(uint32_t p_net_id, SyncGroupId p_group_id);
 	void sync_group_remove_node(NS::ObjectData *p_object_data, SyncGroupId p_group_id);
 
-	/// Use `std::move()` to transfer `p_new_realtime_nodes` and `p_new_deferred_nodes`.
-	void sync_group_replace_nodes(SyncGroupId p_group_id, LocalVector<NS::SyncGroup::RealtimeNodeInfo> &&p_new_realtime_nodes, LocalVector<NS::SyncGroup::DeferredNodeInfo> &&p_new_deferred_nodes);
+	/// Use `std::move()` to transfer `p_new_realtime_nodes` and `p_new_trickled_nodes`.
+	void sync_group_replace_nodes(SyncGroupId p_group_id, LocalVector<NS::SyncGroup::RealtimeNodeInfo> &&p_new_realtime_nodes, LocalVector<NS::SyncGroup::TrickledNodeInfo> &&p_new_trickled_nodes);
 
 	void sync_group_remove_all_nodes(SyncGroupId p_group_id);
 	void sync_group_move_peer_to(int p_peer_id, SyncGroupId p_group_id);
 	SyncGroupId sync_group_get_peer_group(int p_peer_id) const;
 	const LocalVector<int> *sync_group_get_peers(SyncGroupId p_group_id) const;
 
-	void sync_group_set_deferred_update_rate_by_id(uint32_t p_node_id, SyncGroupId p_group_id, real_t p_update_rate);
-	void sync_group_set_deferred_update_rate(NS::ObjectData *p_object_data, SyncGroupId p_group_id, real_t p_update_rate);
-	real_t sync_group_get_deferred_update_rate_by_id(uint32_t p_node_id, SyncGroupId p_group_id) const;
-	real_t sync_group_get_deferred_update_rate(const NS::ObjectData *p_object_data, SyncGroupId p_group_id) const;
+	void sync_group_set_trickled_update_rate_by_id(uint32_t p_node_id, SyncGroupId p_group_id, real_t p_update_rate);
+	void sync_group_set_trickled_update_rate(NS::ObjectData *p_object_data, SyncGroupId p_group_id, real_t p_update_rate);
+	real_t sync_group_get_trickled_update_rate_by_id(uint32_t p_node_id, SyncGroupId p_group_id) const;
+	real_t sync_group_get_trickled_update_rate(const NS::ObjectData *p_object_data, SyncGroupId p_group_id) const;
 
 	void sync_group_set_user_data(SyncGroupId p_group_id, uint64_t p_user_ptr);
 	uint64_t sync_group_get_user_data(SyncGroupId p_group_id) const;

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -317,7 +317,7 @@ public:
 		void update_from(const RealtimeNodeInfo &p_other) {}
 	};
 
-	struct DeferredNodeInfo {
+	struct TrickledNodeInfo {
 		struct ObjectData *od = nullptr;
 
 		/// The node update rate, relative to the godot physics processing rate.
@@ -332,15 +332,15 @@ public:
 		/// INTERNAL
 		bool _unknown = false;
 
-		DeferredNodeInfo() = default;
-		DeferredNodeInfo(const DeferredNodeInfo &) = default;
-		DeferredNodeInfo &operator=(const DeferredNodeInfo &) = default;
-		DeferredNodeInfo &operator=(DeferredNodeInfo &&) = default;
-		DeferredNodeInfo(struct ObjectData *p_nd) :
+		TrickledNodeInfo() = default;
+		TrickledNodeInfo(const TrickledNodeInfo &) = default;
+		TrickledNodeInfo &operator=(const TrickledNodeInfo &) = default;
+		TrickledNodeInfo &operator=(TrickledNodeInfo &&) = default;
+		TrickledNodeInfo(struct ObjectData *p_nd) :
 				od(p_nd) {}
-		bool operator==(const DeferredNodeInfo &p_other) { return od == p_other.od; }
+		bool operator==(const TrickledNodeInfo &p_other) { return od == p_other.od; }
 
-		void update_from(const DeferredNodeInfo &p_other) {
+		void update_from(const TrickledNodeInfo &p_other) {
 			update_rate = p_other.update_rate;
 		}
 	};
@@ -349,8 +349,8 @@ private:
 	bool realtime_sync_nodes_list_changed = false;
 	LocalVector<RealtimeNodeInfo> realtime_sync_nodes;
 
-	bool deferred_sync_nodes_list_changed = false;
-	LocalVector<DeferredNodeInfo> deferred_sync_nodes;
+	bool trickled_sync_nodes_list_changed = false;
+	LocalVector<TrickledNodeInfo> trickled_sync_nodes;
 
 public:
 	uint64_t user_data = 0;
@@ -360,27 +360,27 @@ public:
 
 public:
 	bool is_realtime_node_list_changed() const;
-	bool is_deferred_node_list_changed() const;
+	bool is_trickled_node_list_changed() const;
 
 	const LocalVector<NS::SyncGroup::RealtimeNodeInfo> &get_realtime_sync_nodes() const;
-	const LocalVector<NS::SyncGroup::DeferredNodeInfo> &get_deferred_sync_nodes() const;
-	LocalVector<NS::SyncGroup::DeferredNodeInfo> &get_deferred_sync_nodes();
+	const LocalVector<NS::SyncGroup::TrickledNodeInfo> &get_trickled_sync_nodes() const;
+	LocalVector<NS::SyncGroup::TrickledNodeInfo> &get_trickled_sync_nodes();
 
 	void mark_changes_as_notified();
 
 	/// Returns the `index` or `UINT32_MAX` on error.
 	uint32_t add_new_node(struct ObjectData *p_object_data, bool p_realtime);
 	void remove_node(struct ObjectData *p_object_data);
-	void replace_nodes(LocalVector<RealtimeNodeInfo> &&p_new_realtime_nodes, LocalVector<DeferredNodeInfo> &&p_new_deferred_nodes);
+	void replace_nodes(LocalVector<RealtimeNodeInfo> &&p_new_realtime_nodes, LocalVector<TrickledNodeInfo> &&p_new_trickled_nodes);
 	void remove_all_nodes();
 
 	void notify_new_variable(struct ObjectData *p_object_data, const std::string &p_var_name);
 	void notify_variable_changed(struct ObjectData *p_object_data, const std::string &p_var_name);
 
-	void set_deferred_update_rate(struct ObjectData *p_object_data, real_t p_update_rate);
-	real_t get_deferred_update_rate(const struct ObjectData *p_object_data) const;
+	void set_trickled_update_rate(struct ObjectData *p_object_data, real_t p_update_rate);
+	real_t get_trickled_update_rate(const struct ObjectData *p_object_data) const;
 
-	void sort_deferred_node_by_update_priority();
+	void sort_trickled_node_by_update_priority();
 };
 
 NS_NAMESPACE_END


### PR DESCRIPTION
Aims to implement https://github.com/GodotNetworking/network_synchronizer/issues/86

TODO:
 - Test it out properly
 - Check if we should be using the -ed form of the word, or sometimes `trickling` in the comments are in some namings