### PR TITLE
Correctly rename to "trickled" in error messages

### DIFF
--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -2926,7 +2926,7 @@ void ClientSynchronizer::process_trickled_sync(real_t p_delta) {
 
 #ifdef DEBUG_ENABLED
 		if (!od->func_trickled_apply) {
-			SceneSynchronizerDebugger::singleton()->debug_error(&scene_synchronizer->get_network_interface(), "The function `process_received_trickled_sync_data` skip the node `" + String(od->object_name.c_str()) + "` has an invalid apply epoch function named `trickled_apply`. Remotely you used the function `setup_deferred_sync` properly, while locally you didn't. Fix it.");
+			SceneSynchronizerDebugger::singleton()->debug_error(&scene_synchronizer->get_network_interface(), "The function `process_received_trickled_sync_data` skip the node `" + String(od->object_name.c_str()) + "` has an invalid apply epoch function named `trickled_apply`. Remotely you used the function `setup_trickled_sync` properly, while locally you didn't. Fix it.");
 			continue;
 		}
 #endif


### PR DESCRIPTION
This continues https://github.com/GameNetworking/network_synchronizer/issues/86

They might have not been applied correctly by wgrep when I globally searched and replaced.

Example of error message without this fix:
![image](https://github.com/GameNetworking/network_synchronizer/assets/11084784/e8c55bfe-6feb-47f6-9ca4-7f60822a7eba)
