### PR TITLE
Fix crash when registering network controllers with scene synchronizers

### DIFF
--- a/networked_controller.h
+++ b/networked_controller.h
@@ -250,6 +250,7 @@ public: // -------------------------------------------------------------- Events
 public:
 	void set_inputs_buffer(const BitArray &p_new_buffer, uint32_t p_metadata_size_in_bit, uint32_t p_size_in_bit);
 
+	void unregister_with_synchronizer(NS::SceneSynchronizerBase *p_synchronizer);
 	void notify_registered_with_synchronizer(NS::SceneSynchronizerBase *p_synchronizer, NS::ObjectData &p_nd);
 	NS::SceneSynchronizerBase *get_scene_synchronizer() const;
 	bool has_scene_synchronizer() const;

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -1092,7 +1092,7 @@ void SceneSynchronizerBase::drop_object_data(NS::ObjectData &p_object_data) {
 
 	if (p_object_data.get_controller()) {
 		// This is a controller, make sure to reset the peers.
-		p_object_data.get_controller()->notify_registered_with_synchronizer(nullptr, p_object_data);
+		p_object_data.get_controller()->unregister_with_synchronizer(this);
 		dirty_peers();
 	}
 


### PR DESCRIPTION
This fixes a crash in The Mirror during startup where sometimes the network synchronizer would try to unregister a network controller that belongs to a previously freed scene synchronizer.

For code clarity, the registering and unregistering have been split into separate methods with guard clauses, instead of having one method try to do both operations.