### PR TITLE
Replace MapFunc::at with get_or_null which does not use exceptions

### DIFF
--- a/net_utilities.h
+++ b/net_utilities.h
@@ -36,21 +36,19 @@ class NetworkedControllerBase;
 namespace MapFunc {
 
 template <class K, class V>
-V *at(std::map<K, V> &p_map, const K &p_key) {
-	try {
-		return &p_map.at(p_key);
-	} catch ([[maybe_unused]] std::out_of_range &e) {
+V *get_or_null(std::map<K, V> &p_map, const K &p_key) {
+	if (p_map.count(p_key) == 0) {
 		return nullptr;
 	}
+	return &p_map.at(p_key);
 }
 
 template <class K, class V>
-const V *at(const std::map<K, V> &p_map, const K &p_key) {
-	try {
-		return &p_map.at(p_key);
-	} catch ([[maybe_unused]] std::out_of_range &e) {
+const V *get_or_null(const std::map<K, V> &p_map, const K &p_key) {
+	if (p_map.count(p_key) == 0) {
 		return nullptr;
 	}
+	return &p_map.at(p_key);
 }
 
 /// Insert or assign the `p_val` into the map at index `p_key`.

--- a/tests/test_simulation.cpp
+++ b/tests/test_simulation.cpp
@@ -48,7 +48,7 @@ public:
 	}
 
 	float get_weight() const {
-		const NS::VarData *vd = NS::MapFunc::at(variables, std::string("weight"));
+		const NS::VarData *vd = NS::MapFunc::get_or_null(variables, std::string("weight"));
 		if (vd) {
 			return vd->data.f32;
 		} else {
@@ -63,7 +63,7 @@ public:
 	}
 
 	Vec3 get_position() const {
-		const NS::VarData *vd = NS::MapFunc::at(variables, std::string("position"));
+		const NS::VarData *vd = NS::MapFunc::get_or_null(variables, std::string("position"));
 		if (vd) {
 			return Vec3::from(*vd);
 		} else {
@@ -107,7 +107,7 @@ public:
 	}
 
 	float get_weight() const {
-		const NS::VarData *vd = NS::MapFunc::at(variables, std::string("weight"));
+		const NS::VarData *vd = NS::MapFunc::get_or_null(variables, std::string("weight"));
 		if (vd) {
 			return vd->data.f32;
 		} else {
@@ -122,7 +122,7 @@ public:
 	}
 
 	Vec3 get_position() const {
-		const NS::VarData *vd = NS::MapFunc::at(variables, std::string("position"));
+		const NS::VarData *vd = NS::MapFunc::get_or_null(variables, std::string("position"));
 		if (vd) {
 			return Vec3::from(*vd);
 		} else {


### PR DESCRIPTION
Fixes #100. With this PR, the netsync module now compiles in Godot with exceptions disabled (this is the default in Godot 4.2 and later). It will still work in earlier versions too.

I changed the function to use `count` to check if it contains the key or not (for `std::map` it will only ever return 0 or 1, so it is effectively a boolean). I also renamed it from `at` to `get_or_null` to make it more clear what it does, and because it does not behave the same as `std::map`'s `at` then we should not name it the same.