### PR TITLE
disable netsync tests in normal startup

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -67,7 +67,7 @@ void initialize_network_synchronizer_module(ModuleInitializationLevel p_level) {
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 #ifdef DEBUG_ENABLED
 		List<String> args = OS::get_singleton()->get_cmdline_args();
-		if (args.find("--unit-test-netsync")) {
+		if (args.find("--editor")) {
 			NS_GD_Test::test_var_data_conversin();
 			NS_Test::test_all();
 		}

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -66,8 +66,11 @@ void initialize_network_synchronizer_module(ModuleInitializationLevel p_level) {
 		GLOBAL_DEF("NetworkSynchronizer/debugger/log_debug_fps_warnings", true);
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 #ifdef DEBUG_ENABLED
-		NS_GD_Test::test_var_data_conversin();
-		NS_Test::test_all();
+		List<String> args = OS::get_singleton()->get_cmdline_args();
+		if (args.find("--unit-test-netsync")) {
+			NS_GD_Test::test_var_data_conversin();
+			NS_Test::test_all();
+		}
 #endif
 	}
 }


### PR DESCRIPTION
Added:
- --unit-test-netsync so we can run unit tests optionally

Note: 
This stuff needs ported properly to the latest engine IMO