### PR TITLE
Fixes the jittering that was possible to observe when the other players moves forward

### DIFF
--- a/core/net_utilities.h
+++ b/core/net_utilities.h
@@ -78,13 +78,13 @@ const V &at(const std::map<K, V> &p_map, const K &p_key, const V &p_default) {
 	}
 }
 
-/// Insert or assign the `p_val` into the map at index `p_key`.
+/// Insert or update the `p_val` into the map at index `p_key`.
 template <class K, class V>
 void assign(std::map<K, V> &p_map, const K &p_key, const V &p_val) {
 	p_map.insert_or_assign(p_key, p_val);
 }
 
-/// Insert or assign the `p_val` into the map at index `p_key`.
+/// Insert or update the `p_val` into the map at index `p_key`.
 template <class K, class V>
 void assign(std::map<K, V> &p_map, const K &p_key, V &&p_val) {
 	p_map.insert_or_assign(p_key, std::move(p_val));

--- a/core/net_utilities.h
+++ b/core/net_utilities.h
@@ -199,23 +199,24 @@ void remove_unordered(std::vector<V> &r_vec, const T &p_val) {
 }
 
 // Swap the element at position with the last one, then removes it.
-template <class V, typename T>
+template <class V>
 void remove_at(std::vector<V> &r_vec, std::size_t p_index) {
-	if (r_vec.size() >= p_index) {
+	if (r_vec.size() <= p_index) {
 		return;
 	}
 
-	remove(r_vec, r_vec.begin() + p_index);
+	r_vec.erase(r_vec.begin() + p_index);
 }
 
 // Swap the element at position with the last one, then removes it.
-template <class V, typename T>
+template <class V>
 void remove_at_unordered(std::vector<V> &r_vec, std::size_t p_index) {
-	if (r_vec.size() >= p_index) {
+	if (r_vec.size() <= p_index) {
 		return;
 	}
 
-	remove_unordered(r_vec, r_vec.begin() + p_index);
+	std::iter_swap(r_vec.begin() + p_index, r_vec.rbegin());
+	r_vec.pop_back();
 }
 } //namespace VecFunc
 

--- a/core/net_utilities.h
+++ b/core/net_utilities.h
@@ -198,7 +198,7 @@ void remove_unordered(std::vector<V> &r_vec, const T &p_val) {
 	}
 }
 
-// Swap the element at position with the last one, then removes it.
+// Removes the element without changing order.
 template <class V>
 void remove_at(std::vector<V> &r_vec, std::size_t p_index) {
 	if (r_vec.size() <= p_index) {

--- a/core/peer_networked_controller.cpp
+++ b/core/peer_networked_controller.cpp
@@ -1,5 +1,3 @@
-#pragma optimize("", off) // TODO remove this, which is here just to get good debugging info.
-
 #include "peer_networked_controller.h"
 
 #include "core/config/project_settings.h"
@@ -1752,12 +1750,6 @@ bool DollController::__pcr__fetch_recovery_info(
 #endif
 	);
 
-	// TODO remove this.
-	if (r_differences_info) {
-		for (auto d : *r_differences_info) {
-			SceneSynchronizerBase::__print_line(d);
-		}
-	}
 	return compare;
 }
 

--- a/core/peer_networked_controller.cpp
+++ b/core/peer_networked_controller.cpp
@@ -1709,7 +1709,6 @@ void DollController::on_snapshot_applied(
 	ENSURE_MSG(input_count > 0, "This function is not supposed to work with 0 inputs. Report this bug.")
 
 	// 3. Fetch the best input to start processing.
-	// TODO consider to scale this dynamically to slowly catchup with the server, as too drastic change may result in a less stable simulation.
 	const int optimal_input_count = p_frame_count_to_rewind + optimal_queued_inputs;
 
 	// The lag compensation algorithm offsets the available
@@ -1721,10 +1720,10 @@ void DollController::on_snapshot_applied(
 		// It has less inputs than the optimal input count defined.
 		// In  this case the offset, mention above, is going to be positive;
 		// making sure the available frames_input are used at the end of the processing
-		// so the `optimal_queued_inputs` is left at the endo of the rewinding.
+		// so the `optimal_queued_inputs` is left at the end of the rewinding.
 		const int missing_inputs = optimal_input_count - input_count;
-
 		queued_instant_offset = missing_inputs;
+
 	} else {
 		// It has more inputs than the optimal input count defined.
 		// In this case the offset is negative, meaning it throws away all the

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -407,6 +407,7 @@ public:
 	virtual void process(double p_delta) override;
 	void on_state_validated(FrameIndex p_frame_index, bool p_detected_desync);
 	void notify_frame_checked(FrameIndex p_input_id);
+	void notify_frame_processing(FrameIndex p_input_id);
 
 	void on_received_server_snapshot(const Snapshot &p_snapshot);
 	void on_snapshot_update_finished(const Snapshot &p_snapshot);

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -408,7 +408,10 @@ public:
 
 	void on_received_server_snapshot(const Snapshot &p_snapshot);
 	void on_snapshot_update_finished(const Snapshot &p_snapshot);
-	void copy_controlled_objects_snapshot(const Snapshot &p_snapshot, std::vector<DollSnapshot> &r_snapshots);
+	void copy_controlled_objects_snapshot(
+			const Snapshot &p_snapshot,
+			std::vector<DollSnapshot> &r_snapshots,
+			bool p_store_even_when_doll_is_not_processing);
 
 	// Checks whether this doll requires a reconciliation.
 	// The check done is relative to the doll timeline, and not the scene sync timeline.

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -405,9 +405,10 @@ public:
 	int fetch_optimal_queued_inputs() const;
 	virtual bool fetch_next_input(double p_delta) override;
 	virtual void process(double p_delta) override;
+
 	void on_state_validated(FrameIndex p_frame_index, bool p_detected_desync);
 	void notify_frame_checked(FrameIndex p_input_id);
-	void notify_frame_processing(FrameIndex p_input_id);
+	void clear_previously_generated_client_snapshots();
 
 	void on_received_server_snapshot(const Snapshot &p_snapshot);
 	void on_snapshot_update_finished(const Snapshot &p_snapshot);

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -383,9 +383,14 @@ public:
 	NS::PHandler event_handler_client_snapshot_updated = NS::NullPHandler;
 	NS::PHandler event_handler_snapshot_applied = NS::NullPHandler;
 
-	FrameIndex last_checked_input = FrameIndex::NONE;
-	FrameIndex last_doll_checked_input = FrameIndex::NONE;
-	int queued_instant_offset = 0;
+	// The lastest `FrameIndex` validated.
+	FrameIndex last_doll_validated_input = FrameIndex::NONE;
+	// This parameter is useful to specify when the `last_doll_compared_snapshot`
+	// is set. Since the function `__pcr__fetch_recovery_info` is not always called.
+	bool is_last_doll_compared_input_valid = false;
+	// The lastest `FrameIndex` on which the server / doll snapshots were compared.
+	FrameIndex last_doll_compared_input = FrameIndex::NONE;
+	FrameIndex queued_frame_index_to_process = FrameIndex{ 0 };
 	int queued_instant_to_process = -1;
 
 	// Contains the controlled nodes frames snapshot.
@@ -413,17 +418,20 @@ public:
 			std::vector<DollSnapshot> &r_snapshots,
 			bool p_store_even_when_doll_is_not_processing);
 
+	FrameIndex fetch_best_recoverable_snapshot(DollSnapshot *&r_client_snapshot, DollSnapshot *&r_server_snapshot);
+
 	// Checks whether this doll requires a reconciliation.
 	// The check done is relative to the doll timeline, and not the scene sync timeline.
 	bool __pcr__fetch_recovery_info(
-			FrameIndex p_checking_frame_index,
+			const FrameIndex p_checking_frame_index,
+			const int p_frame_count_to_rewind,
 			Snapshot *r_no_rewind_recover,
 			std::vector<std::string> *r_differences_info
 #ifdef DEBUG_ENABLED
 			,
 			std::vector<ObjectNetId> *r_different_node_data
 #endif
-	) const;
+	);
 
 	void on_snapshot_applied(const Snapshot &p_snapshot, const int p_frame_count_to_rewind);
 

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -399,7 +399,6 @@ public:
 
 	virtual bool receive_inputs(const Vector<uint8_t> &p_data) override;
 	void on_rewind_frame_begin(FrameIndex p_input_id, int p_index, int p_count);
-	int count_queued_inputs() const;
 	int fetch_optimal_queued_inputs() const;
 	virtual bool fetch_next_input(double p_delta) override;
 	virtual void process(double p_delta) override;
@@ -415,7 +414,6 @@ public:
 	bool __pcr__fetch_recovery_info(
 			FrameIndex p_checking_frame_index,
 			Snapshot *r_no_rewind_recover,
-			int p_predicted_frames,
 			std::vector<std::string> *r_differences_info
 #ifdef DEBUG_ENABLED
 			,
@@ -423,7 +421,7 @@ public:
 #endif
 	) const;
 
-	void on_snapshot_applied(const Snapshot &p_snapshot);
+	void on_snapshot_applied(const Snapshot &p_snapshot, const int p_frame_count_to_rewind);
 
 	DollSnapshot *find_snapshot_by_snapshot_id(std::vector<DollSnapshot> &p_snapshots, FrameIndex p_index) const;
 	const DollSnapshot *find_snapshot_by_snapshot_id(const std::vector<DollSnapshot> &p_snapshots, FrameIndex p_index) const;

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -430,10 +430,10 @@ public:
 #endif
 	);
 
-	void on_snapshot_applied(const Snapshot &p_snapshot, const int p_frame_count_to_rewind);
-
-	DollSnapshot *find_snapshot_by_snapshot_id(std::vector<DollSnapshot> &p_snapshots, FrameIndex p_index) const;
-	const DollSnapshot *find_snapshot_by_snapshot_id(const std::vector<DollSnapshot> &p_snapshots, FrameIndex p_index) const;
+	void on_snapshot_applied(const Snapshot &p_global_server_snapshot, const int p_frame_count_to_rewind);
+	void apply_snapshot_no_input_reconciliation(const Snapshot &p_global_server_snapshot);
+	void apply_snapshot_instant_input_reconciliation(const Snapshot &p_global_server_snapshot, const int p_frame_count_to_rewind);
+	void apply_snapshot_rewinding_input_reconciliation(const Snapshot &p_global_server_snapshot, const int p_frame_count_to_rewind);
 };
 
 /// This controller is used when the game instance is not a peer of any kind.

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -385,9 +385,6 @@ public:
 
 	// The lastest `FrameIndex` validated.
 	FrameIndex last_doll_validated_input = FrameIndex::NONE;
-	// This parameter is useful to specify when the `last_doll_compared_snapshot`
-	// is set. Since the function `__pcr__fetch_recovery_info` is not always called.
-	bool is_last_doll_compared_input_valid = false;
 	// The lastest `FrameIndex` on which the server / doll snapshots were compared.
 	FrameIndex last_doll_compared_input = FrameIndex::NONE;
 	FrameIndex queued_frame_index_to_process = FrameIndex{ 0 };
@@ -418,7 +415,7 @@ public:
 			std::vector<DollSnapshot> &r_snapshots,
 			bool p_store_even_when_doll_is_not_processing);
 
-	FrameIndex fetch_last_processed_recoverable_snapshot(DollSnapshot *&r_client_snapshot, DollSnapshot *&r_server_snapshot);
+	FrameIndex fetch_checkable_snapshot(DollSnapshot *&r_client_snapshot, DollSnapshot *&r_server_snapshot);
 
 	// Checks whether this doll requires a reconciliation.
 	// The check done is relative to the doll timeline, and not the scene sync timeline.

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -418,7 +418,7 @@ public:
 			std::vector<DollSnapshot> &r_snapshots,
 			bool p_store_even_when_doll_is_not_processing);
 
-	FrameIndex fetch_best_recoverable_snapshot(DollSnapshot *&r_client_snapshot, DollSnapshot *&r_server_snapshot);
+	FrameIndex fetch_last_processed_recoverable_snapshot(DollSnapshot *&r_client_snapshot, DollSnapshot *&r_server_snapshot);
 
 	// Checks whether this doll requires a reconciliation.
 	// The check done is relative to the doll timeline, and not the scene sync timeline.

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -334,7 +334,7 @@ struct PlayerController final : public Controller {
 	FrameIndex get_stored_frame_index(int p_i) const;
 	virtual FrameIndex get_current_frame_index() const override;
 
-	void on_rewind_frame_begin(FrameIndex p_input_id, int p_index, int p_count);
+	void on_rewind_frame_begin(FrameIndex p_frame_index, int p_rewinding_index, int p_rewinding_frame_count);
 	bool has_another_instant_to_process_after(int p_i) const;
 	virtual void process(double p_delta) override;
 	void on_state_validated(FrameIndex p_frame_index, bool p_detected_desync);
@@ -385,6 +385,7 @@ public:
 
 	FrameIndex last_checked_input = FrameIndex::NONE;
 	FrameIndex last_doll_checked_input = FrameIndex::NONE;
+	int queued_instant_offset = 0;
 	int queued_instant_to_process = -1;
 
 	// Contains the controlled nodes frames snapshot.
@@ -398,7 +399,7 @@ public:
 	~DollController();
 
 	virtual bool receive_inputs(const Vector<uint8_t> &p_data) override;
-	void on_rewind_frame_begin(FrameIndex p_input_id, int p_index, int p_count);
+	void on_rewind_frame_begin(FrameIndex p_frame_index, int p_rewinding_index, int p_rewinding_frame_count);
 	int fetch_optimal_queued_inputs() const;
 	virtual bool fetch_next_input(double p_delta) override;
 	virtual void process(double p_delta) override;

--- a/core/snapshot.cpp
+++ b/core/snapshot.cpp
@@ -144,6 +144,7 @@ bool NS::Snapshot::compare(
 	bool is_equal = true;
 #endif
 
+	// Compares the simualted object first.
 	if (p_snap_A.simulated_objects.size() != p_snap_B.simulated_objects.size()) {
 		if (r_differences_info) {
 			r_differences_info->push_back("Difference detected: simulated_object count is different snapA: " + std::to_string(p_snap_A.simulated_objects.size()) + " snapB: " + std::to_string(p_snap_B.simulated_objects.size()) + ".");

--- a/core/snapshot.cpp
+++ b/core/snapshot.cpp
@@ -116,6 +116,7 @@ NS::Snapshot NS::Snapshot::make_copy(const Snapshot &p_other) {
 void NS::Snapshot::copy(const Snapshot &p_other) {
 	input_id = p_other.input_id;
 	simulated_objects = p_other.simulated_objects;
+	peers_frames_index = p_other.peers_frames_index;
 	object_vars.resize(p_other.object_vars.size());
 	for (std::size_t i = 0; i < p_other.object_vars.size(); i++) {
 		object_vars[i].resize(p_other.object_vars[i].size());
@@ -195,6 +196,7 @@ bool NS::Snapshot::compare(
 		r_no_rewind_recover->object_vars.resize(MAX(p_snap_A.object_vars.size(), p_snap_B.object_vars.size()));
 	}
 
+	// TODO instead to iterate over all the object_vars, iterate over the simulated. This will make it save a bunch of time.
 	for (ObjectNetId net_object_id = { 0 }; net_object_id < ObjectNetId{ uint32_t(p_snap_A.object_vars.size()) }; net_object_id += 1) {
 		const NS::ObjectData *rew_object_data = scene_synchronizer.get_object_data(net_object_id);
 		if (rew_object_data == nullptr || rew_object_data->realtime_sync_enabled_on_client == false) {

--- a/core/snapshot.h
+++ b/core/snapshot.h
@@ -15,6 +15,12 @@ struct Snapshot final {
 	/// The variable array order also matter.
 	std::vector<std::vector<NameAndVar>> object_vars;
 
+	/// The executed FrameIndex for the simulating peers.
+	/// NOTE: Due to the nature of the doll simulation, when comparing the
+	///       server snapshot with the client snapshot this map is never checked.
+	///       This map is used by the Doll-controller's reconciliation algorithm.
+	std::map<int, FrameIndex> peers_frames_index;
+
 	bool has_custom_data = false;
 
 	/// Custom variable specified by the user.

--- a/core/snapshot.h
+++ b/core/snapshot.h
@@ -7,7 +7,7 @@
 namespace NS {
 class SceneSynchronizerBase;
 
-struct Snapshot {
+struct Snapshot final {
 	FrameIndex input_id = FrameIndex::NONE;
 	std::vector<NS::ObjectNetId> simulated_objects;
 	/// The Node variables in a particular frame. The order of this vector

--- a/core/var_data.cpp
+++ b/core/var_data.cpp
@@ -10,7 +10,8 @@ VarData::VarData() {
 	memset(&data, 0, sizeof(data));
 }
 
-VarData::VarData(double x, double y, double z, double w) {
+VarData::VarData(double x, double y, double z, double w) :
+		VarData() {
 	data.vec.x = x;
 	data.vec.y = y;
 	data.vec.z = z;

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -165,6 +165,11 @@ void SceneSynchronizerBase::conclude() {
 void SceneSynchronizerBase::process(double p_delta) {
 	NS_PROFILE
 
+	if (settings_changed) {
+		event_settings_changed.broadcast(settings);
+		settings_changed = false;
+	}
+
 #ifdef DEBUG_ENABLED
 	ASSERT_COND_MSG(synchronizer, "Never execute this function unless this synchronizer is ready.");
 
@@ -305,6 +310,20 @@ bool SceneSynchronizerBase::is_variable_registered(ObjectLocalId p_id, const std
 		return od->find_variable_id(p_variable) != VarId::NONE;
 	}
 	return false;
+}
+
+void SceneSynchronizerBase::set_settings(Settings &p_settings) {
+	settings = p_settings;
+	settings_changed = true;
+}
+
+Settings &SceneSynchronizerBase::get_settings_mutable() {
+	settings_changed = true;
+	return settings;
+}
+
+const Settings &SceneSynchronizerBase::get_settings() const {
+	return settings;
 }
 
 void SceneSynchronizerBase::register_app_object(ObjectHandle p_app_object_handle, ObjectLocalId *out_id) {

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -220,7 +220,14 @@ public: // -------------------------------------------------------------- Events
 	Processor<int /*p_peer*/, bool /*p_connected*/, bool /*p_enabled*/> event_peer_status_updated;
 	Processor<FrameIndex, bool /*p_desync_detected*/> event_state_validated;
 	Processor<FrameIndex, int /*p_peer*/> event_sent_snapshot;
-	Processor<const Snapshot & /*p_received_snapshot*/> event_received_snapshot;
+	/// This event is emitted when the current client state is stored into the snapshot.
+	/// NOTE: This even is also executed during the rewinding, to update the previously stored states.
+	/// NOTE: Something to remark is that the Snapshot data passed, is equal to
+	///       the data read through the get functions, at the moment of the event.
+	///       So, you can assume the snapshot contains the result of the last executed input.
+	Processor<const Snapshot & /*p_snapshot*/> event_snapshot_update_finished;
+	Processor<const Snapshot & /*p_snapshot*/> event_snapshot_applied;
+	Processor<const Snapshot & /*p_received_snapshot*/> event_received_server_snapshot;
 	Processor<FrameIndex, int /*p_index*/, int /*p_count*/> event_rewind_frame_begin;
 	Processor<FrameIndex, ObjectHandle /*p_app_object_handle*/, const std::vector<std::string> & /*p_var_names*/, const std::vector<VarData> & /*p_client_values*/, const std::vector<VarData> & /*p_server_values*/> event_desync_detected_with_info;
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -789,7 +789,8 @@ public:
 			DataBuffer &p_snapshot,
 			void *p_user_pointer,
 			void (*p_custom_data_parse)(void *p_user_pointer, VarData &&p_custom_data),
-			void (*p_ode_parse)(void *p_user_pointer, NS::ObjectData *p_object_data),
+			void (*p_object_parse)(void *p_user_pointer, NS::ObjectData *p_object_data),
+			void (*p_peers_frame_index_parse)(void *p_user_pointer, std::map<int, FrameIndex> &&p_frames_index),
 			void (*p_input_id_parse)(void *p_user_pointer, FrameIndex p_frame_index),
 			void (*p_variable_parse)(void *p_user_pointer, NS::ObjectData *p_object_data, VarId p_var_id, VarData &&p_value),
 			void (*p_simulated_objects_parse)(void *p_user_pointer, std::vector<ObjectNetId> &&p_simulated_objects));

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -49,6 +49,17 @@ struct LagCompensationSettings {
 	/// If true, the dolls (The objects controlled by other player) will guess
 	/// the input if the input is missing.
 	bool doll_allow_guess_input_when_missing = true;
+
+	/// Forces the input reconciliation when the doll accumulates an input count
+	/// that surpassed by X (defined below) the amount of frames to reconcile.
+	/// NOTICE: This MUST never be less than 1;
+	/// NOTICE: This should not be too low, or the doll will jump arround too much.
+	/// NOTICE: To disable this featues you can set this to 10 or more.
+	int doll_force_input_reconciliation = 10;
+
+	/// The minimum amount of frames needed to trigger the input reconciliation.
+	/// NOTE: This must be more than 1
+	int doll_force_input_reconciliation_min_frames = 5;
 };
 
 struct Settings {
@@ -831,13 +842,18 @@ private:
 
 	bool __pcr__fetch_recovery_info(
 			const FrameIndex p_input_id,
+			const int p_rewind_frame_count,
 			const struct PlayerController &p_local_player_controller,
 			Snapshot &r_no_rewind_recover);
 
-	void __pcr__sync__rewind(FrameIndex p_last_checked_input_id, const PlayerController &p_local_player_controller);
+	void __pcr__sync__rewind(
+			FrameIndex p_last_checked_input_id,
+			const int p_rewind_frame_count,
+			const PlayerController &p_local_player_controller);
 
 	void __pcr__rewind(
 			const FrameIndex p_checkable_frame_index,
+			const int p_rewind_frame_count,
 			PeerNetworkedController *p_controller,
 			PlayerController *p_player_controller);
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -284,6 +284,9 @@ public:
 		return *synchronizer_manager;
 	}
 
+	const Synchronizer *get_synchronizer_internal() const { return synchronizer; }
+	Synchronizer *get_synchronizer_internal() { return synchronizer; }
+
 	void set_frames_per_seconds(int p_fps);
 	int get_frames_per_seconds() const;
 
@@ -838,11 +841,17 @@ private:
 
 	void update_client_snapshot(Snapshot &p_snapshot);
 	void update_simulated_objects_list(const std::vector<ObjectNetId> &p_simulated_objects);
+
+public:
 	void apply_snapshot(
 			const Snapshot &p_snapshot,
-			int p_flag,
+			const int p_flag,
 			std::vector<std::string> *r_applied_data_info,
-			bool p_skip_custom_data = false);
+			const bool p_skip_custom_data = false,
+			const bool p_skip_simulated_objects_update = false,
+			const bool p_disable_apply_non_doll_controlled_only = false,
+			const bool p_skip_snapshot_applied_event_broadcast = false,
+			const bool p_skip_change_event = false);
 };
 
 /// This is used to make sure we can safely convert any `BaseType` defined by

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -226,7 +226,7 @@ public: // -------------------------------------------------------------- Events
 	///       the data read through the get functions, at the moment of the event.
 	///       So, you can assume the snapshot contains the result of the last executed input.
 	Processor<const Snapshot & /*p_snapshot*/> event_snapshot_update_finished;
-	Processor<const Snapshot & /*p_snapshot*/> event_snapshot_applied;
+	Processor<const Snapshot & /*p_snapshot*/, int /*p_frame_count_to_rewind*/> event_snapshot_applied;
 	Processor<const Snapshot & /*p_received_snapshot*/> event_received_server_snapshot;
 	Processor<FrameIndex, int /*p_index*/, int /*p_count*/> event_rewind_frame_begin;
 	Processor<FrameIndex, ObjectHandle /*p_app_object_handle*/, const std::vector<std::string> & /*p_var_names*/, const std::vector<VarData> & /*p_client_values*/, const std::vector<VarData> & /*p_server_values*/> event_desync_detected_with_info;
@@ -816,7 +816,7 @@ private:
 			const struct PlayerController &p_local_player_controller,
 			Snapshot &r_no_rewind_recover);
 
-	void __pcr__sync__rewind();
+	void __pcr__sync__rewind(FrameIndex p_last_checked_input_id, const PlayerController &p_local_player_controller);
 
 	void __pcr__rewind(
 			const FrameIndex p_checkable_frame_index,
@@ -847,6 +847,8 @@ public:
 	void apply_snapshot(
 			const Snapshot &p_snapshot,
 			const int p_flag,
+			// The frames rewinded just after this function.
+			const int p_frame_count_to_rewind,
 			std::vector<std::string> *r_applied_data_info,
 			const bool p_skip_custom_data = false,
 			const bool p_skip_simulated_objects_update = false,

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -426,6 +426,10 @@ void test_simulation_reconciliation(float p_frame_confirmation_timespan) {
 	// Run another 30 frames.
 	test.do_test(30);
 
+	// Ensure it was able to reconcily in exactly 1 frame.
+	ASSERT_COND(test.peer1_desync_detected.size() == 1);
+	ASSERT_COND(test.peer2_desync_detected.size() == 1);
+
 	// Make sure the reconciliation was successful.
 	// NOTE: 45 is a margin established basing on the `p_frame_confirmation_timespan`.
 	const NS::FrameIndex ensure_no_desync_after{ 45 };
@@ -462,7 +466,7 @@ void test_simulation_with_hiccups(TestDollSimulationStorePositions &test) {
 		}
 	}
 
-	test.do_test(30);
+	test.do_test(100);
 
 	const NS::FrameIndex controller_1_last_player_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
 	const NS::FrameIndex controller_2_last_player_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
@@ -477,8 +481,8 @@ void test_simulation_with_hiccups(TestDollSimulationStorePositions &test) {
 
 	// Make sure the last frames are identical.
 	test.assert_positions(
-			test.peer1_desync_detected.back(),
-			test.peer2_desync_detected.back());
+			test.peer1_desync_detected.back() + 10,
+			test.peer2_desync_detected.back() + 10);
 }
 
 void test_simulation_with_latency() {
@@ -628,17 +632,14 @@ void test_latency() {
 }
 
 void test_doll_simulation() {
-	// TODO enable these tests.
-	//test_simulation_without_reconciliation(0.0);
-	//test_simulation_without_reconciliation(1. / 30.);
-	//test_simulation_reconciliation(0.0);
-	//test_simulation_reconciliation(1.0 / 10.0);
-	//test_simulation_with_latency();
+	test_simulation_without_reconciliation(0.0);
+	test_simulation_without_reconciliation(1. / 30.);
+	test_simulation_reconciliation(0.0);
+	test_simulation_reconciliation(1.0 / 10.0);
+	test_simulation_with_latency();
 	test_simulation_with_hiccups();
 	// TODO test with great latency and lag compensation.
-	//test_latency();
-
-	ASSERT_COND(false);
+	test_latency();
 }
 
 }; //namespace NS_Test

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -86,22 +86,25 @@ public:
 		}
 
 		// TODO remove this, is here just for debug.
-		if (authoritative_peer_id != 2) {
-			return;
-		}
-		NS::PeerNetworkedController *controller = scene_owner->scene_sync->get_controller_for_peer(authoritative_peer_id);
-		NS::FrameIndex fi = controller->get_current_frame_index();
-		std::string frame_info;
-		frame_info += "FrameIndex: " + fi;
-		frame_info += " initial X: " + std::to_string(current.data.vec.x) + " Y: " + std::to_string(current.data.vec.y);
-		frame_info += " input: " + std::string(advance_or_turn ? "advance" : "turn");
+		const bool debug_procesing = false;
+		if (!debug_procesing) {
+			if (authoritative_peer_id != 2) {
+				return;
+			}
+			NS::PeerNetworkedController *controller = scene_owner->scene_sync->get_controller_for_peer(authoritative_peer_id);
+			NS::FrameIndex fi = controller->get_current_frame_index();
+			std::string frame_info;
+			frame_info += "FrameIndex: " + fi;
+			frame_info += " initial X: " + std::to_string(current.data.vec.x) + " Y: " + std::to_string(current.data.vec.y);
+			frame_info += " input: " + std::string(advance_or_turn ? "advance" : "turn");
 
-		if (controller->is_doll_controller()) {
-			NS::SceneSynchronizerBase::__print_line("Doll controller " + frame_info);
-		} else if (controller->is_player_controller()) {
-			NS::SceneSynchronizerBase::__print_line("Player controller " + frame_info);
-		} else if (controller->is_server_controller()) {
-			NS::SceneSynchronizerBase::__print_line("Server controller " + frame_info);
+			if (controller->is_doll_controller()) {
+				NS::SceneSynchronizerBase::__print_line("Doll controller " + frame_info);
+			} else if (controller->is_player_controller()) {
+				NS::SceneSynchronizerBase::__print_line("Player controller " + frame_info);
+			} else if (controller->is_server_controller()) {
+				NS::SceneSynchronizerBase::__print_line("Server controller " + frame_info);
+			}
 		}
 	}
 

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -426,12 +426,59 @@ void test_simulation_reconciliation(float p_frame_confirmation_timespan) {
 	// Run another 30 frames.
 	test.do_test(30);
 
-	// Make sure there was 1 desyc
-	ASSERT_COND(test.peer1_desync_detected.size() == 1);
-	ASSERT_COND(test.peer2_desync_detected.size() == 1);
+	// Make sure the reconciliation was successful.
+	// NOTE: 45 is a margin established basing on the `p_frame_confirmation_timespan`.
+	const NS::FrameIndex ensure_no_desync_after{ 45 };
+	test.assert_no_desync(ensure_no_desync_after, ensure_no_desync_after);
 
 	// and despite that the simulations are correct.
-	test.assert_positions(test.peer1_desync_detected.front(), test.peer2_desync_detected.front());
+	test.assert_positions(ensure_no_desync_after, ensure_no_desync_after);
+}
+
+void test_simulation_with_hiccups(TestDollSimulationStorePositions &test) {
+	// Partially process.
+	test.network_properties.rtt_seconds = 0.0;
+
+	{
+		NS::FrameIndex controller_1_doll_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
+		NS::FrameIndex controller_2_doll_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
+
+		for (int i = 0; i < 10; i++) {
+			if (i % 2 == 0) {
+				test.do_test(10, false, true, false, true);
+			} else {
+				test.do_test(10, false, true, true, false);
+			}
+
+			const NS::FrameIndex controller_1_doll_new_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
+			const NS::FrameIndex controller_2_doll_new_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
+
+			// Ensure the doll keep going forward.
+			ASSERT_COND(controller_1_doll_frame_index == NS::FrameIndex::NONE || controller_1_doll_frame_index <= controller_1_doll_new_frame_index);
+			ASSERT_COND(controller_2_doll_frame_index == NS::FrameIndex::NONE || controller_2_doll_frame_index <= controller_2_doll_new_frame_index);
+
+			controller_1_doll_frame_index = controller_1_doll_new_frame_index;
+			controller_2_doll_frame_index = controller_2_doll_new_frame_index;
+		}
+	}
+
+	test.do_test(30);
+
+	const NS::FrameIndex controller_1_last_player_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
+	const NS::FrameIndex controller_2_last_player_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
+
+	const NS::FrameIndex controller_1_last_doll_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
+	const NS::FrameIndex controller_2_last_doll_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
+
+	const int latency_factor = 15;
+
+	ASSERT_COND(controller_1_last_player_frame_index - latency_factor <= controller_1_last_doll_frame_index);
+	ASSERT_COND(controller_2_last_player_frame_index - latency_factor <= controller_2_last_doll_frame_index);
+
+	// Make sure the last frames are identical.
+	test.assert_positions(
+			test.peer1_desync_detected.back(),
+			test.peer2_desync_detected.back());
 }
 
 void test_simulation_with_latency() {
@@ -527,54 +574,8 @@ void test_simulation_with_latency() {
 				controller_2_last_player_frame_index - latency_factor);
 	}
 
-	// TODO test this again.
-	// TODO consider to remove this or leave it.
 	// Partially process.
-	{
-		test.network_properties.rtt_seconds = 0.0;
-
-		{
-			NS::FrameIndex controller_1_doll_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
-			NS::FrameIndex controller_2_doll_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
-
-			for (int i = 0; i < 10; i++) {
-				if (i % 2 == 0) {
-					test.do_test(10, false, true, false, true);
-				} else {
-					test.do_test(10, false, true, true, false);
-				}
-
-				const NS::FrameIndex controller_1_doll_new_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
-				const NS::FrameIndex controller_2_doll_new_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
-
-				// Ensure the doll keep going forward.
-				ASSERT_COND(controller_1_doll_frame_index <= controller_1_doll_new_frame_index);
-				ASSERT_COND(controller_2_doll_frame_index <= controller_2_doll_new_frame_index);
-
-				controller_1_doll_frame_index = controller_1_doll_new_frame_index;
-				controller_2_doll_frame_index = controller_2_doll_new_frame_index;
-			}
-		}
-
-		test.do_test(10);
-
-		const NS::FrameIndex controller_1_last_player_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
-		const NS::FrameIndex controller_2_last_player_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
-
-		const NS::FrameIndex controller_1_last_doll_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
-		const NS::FrameIndex controller_2_last_doll_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
-
-		const int latency_factor = 15;
-
-		ASSERT_COND(controller_1_last_player_frame_index - latency_factor <= controller_1_last_doll_frame_index);
-		ASSERT_COND(controller_2_last_player_frame_index - latency_factor <= controller_2_last_doll_frame_index);
-
-		test.assert_positions(
-				controller_1_last_player_frame_index - latency_factor,
-				controller_2_last_player_frame_index - latency_factor);
-	}
-
-	int a = 0;
+	test_simulation_with_hiccups(test);
 }
 
 void test_simulation_with_hiccups() {
@@ -582,51 +583,7 @@ void test_simulation_with_hiccups() {
 	test.frame_confirmation_timespan = 1.0 / 10.0;
 	test.init_test();
 
-	// Partially process.
-	test.network_properties.rtt_seconds = 0.0;
-
-	{
-		NS::FrameIndex controller_1_doll_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
-		NS::FrameIndex controller_2_doll_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
-
-		for (int i = 0; i < 10; i++) {
-			if (i % 2 == 0) {
-				test.do_test(10, false, true, false, true);
-			} else {
-				test.do_test(10, false, true, true, false);
-			}
-
-			const NS::FrameIndex controller_1_doll_new_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
-			const NS::FrameIndex controller_2_doll_new_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
-
-			// Ensure the doll keep going forward.
-			ASSERT_COND(controller_1_doll_frame_index == NS::FrameIndex::NONE || controller_1_doll_frame_index <= controller_1_doll_new_frame_index);
-			ASSERT_COND(controller_2_doll_frame_index == NS::FrameIndex::NONE || controller_2_doll_frame_index <= controller_2_doll_new_frame_index);
-
-			controller_1_doll_frame_index = controller_1_doll_new_frame_index;
-			controller_2_doll_frame_index = controller_2_doll_new_frame_index;
-		}
-	}
-
-	test.do_test(30);
-
-	const NS::FrameIndex controller_1_last_player_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
-	const NS::FrameIndex controller_2_last_player_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
-
-	const NS::FrameIndex controller_1_last_doll_frame_index = test.peer_2_scene.scene_sync->get_controller_for_peer(test.peer_1_scene.get_peer())->get_current_frame_index();
-	const NS::FrameIndex controller_2_last_doll_frame_index = test.peer_1_scene.scene_sync->get_controller_for_peer(test.peer_2_scene.get_peer())->get_current_frame_index();
-
-	const int latency_factor = 15;
-
-	ASSERT_COND(controller_1_last_player_frame_index - latency_factor <= controller_1_last_doll_frame_index);
-	ASSERT_COND(controller_2_last_player_frame_index - latency_factor <= controller_2_last_doll_frame_index);
-
-	// Make sure the last frames are identical.
-	test.assert_positions(
-			test.peer1_desync_detected.back(),
-			test.peer2_desync_detected.back());
-
-	int a = 0;
+	test_simulation_with_hiccups(test);
 }
 
 void test_latency() {
@@ -675,9 +632,9 @@ void test_doll_simulation() {
 	//test_simulation_without_reconciliation(0.0);
 	//test_simulation_without_reconciliation(1. / 30.);
 	//test_simulation_reconciliation(0.0);
-	test_simulation_reconciliation(1.0 / 10.0);
+	//test_simulation_reconciliation(1.0 / 10.0);
 	//test_simulation_with_latency();
-	//test_simulation_with_hiccups();
+	test_simulation_with_hiccups();
 	// TODO test with great latency and lag compensation.
 	//test_latency();
 

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -84,28 +84,6 @@ public:
 			// Turn
 			set_xy(current.data.vec.x, current.data.vec.y + 1);
 		}
-
-		// TODO remove this, is here just for debug.
-		const bool debug_procesing = false;
-		if (debug_procesing) {
-			if (authoritative_peer_id != 2) {
-				return;
-			}
-			NS::PeerNetworkedController *controller = scene_owner->scene_sync->get_controller_for_peer(authoritative_peer_id);
-			NS::FrameIndex fi = controller->get_current_frame_index();
-			std::string frame_info;
-			frame_info += "FrameIndex: " + fi;
-			frame_info += " initial X: " + std::to_string(current.data.vec.x) + " Y: " + std::to_string(current.data.vec.y);
-			frame_info += " input: " + std::string(advance_or_turn ? "advance" : "turn");
-
-			if (controller->is_doll_controller()) {
-				NS::SceneSynchronizerBase::__print_line("Doll controller " + frame_info);
-			} else if (controller->is_player_controller()) {
-				NS::SceneSynchronizerBase::__print_line("Player controller " + frame_info);
-			} else if (controller->is_server_controller()) {
-				NS::SceneSynchronizerBase::__print_line("Server controller " + frame_info);
-			}
-		}
 	}
 
 	bool are_inputs_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B) {

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -356,7 +356,7 @@ void test_doll_simulation() {
 	test_latency();
 
 	// TODO Remove this once the test are all implemented.
-	ASSERT_COND(false);
+	//ASSERT_COND(false);
 }
 
 }; //namespace NS_Test

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -11,11 +11,12 @@ void NS_Test::test_all() {
 	NS::LocalSceneSynchronizer::install_local_scene_sync();
 
 	// TODO test DataBuffer.
-	test_data_buffer();
-	test_processor();
-	test_local_network();
-	test_scene_synchronizer();
-	test_simulation();
+	// TODO enable these again.
+	//test_data_buffer();
+	//test_processor();
+	//test_local_network();
+	//test_scene_synchronizer();
+	//test_simulation();
 	test_doll_simulation();
 
 	NS::LocalSceneSynchronizer::uninstall_local_scene_sync();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -11,11 +11,12 @@ void NS_Test::test_all() {
 	NS::LocalSceneSynchronizer::install_local_scene_sync();
 
 	// TODO test DataBuffer.
-	test_data_buffer();
-	test_processor();
-	test_local_network();
-	test_scene_synchronizer();
-	test_simulation();
+	// TODO enable these
+	//test_data_buffer();
+	//test_processor();
+	//test_local_network();
+	//test_scene_synchronizer();
+	//test_simulation();
 	test_doll_simulation();
 
 	NS::LocalSceneSynchronizer::uninstall_local_scene_sync();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -11,12 +11,11 @@ void NS_Test::test_all() {
 	NS::LocalSceneSynchronizer::install_local_scene_sync();
 
 	// TODO test DataBuffer.
-	// TODO enable these
-	//test_data_buffer();
-	//test_processor();
-	//test_local_network();
-	//test_scene_synchronizer();
-	//test_simulation();
+	test_data_buffer();
+	test_processor();
+	test_local_network();
+	test_scene_synchronizer();
+	test_simulation();
 	test_doll_simulation();
 
 	NS::LocalSceneSynchronizer::uninstall_local_scene_sync();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -11,12 +11,11 @@ void NS_Test::test_all() {
 	NS::LocalSceneSynchronizer::install_local_scene_sync();
 
 	// TODO test DataBuffer.
-	// TODO enable these again.
-	//test_data_buffer();
-	//test_processor();
-	//test_local_network();
-	//test_scene_synchronizer();
-	//test_simulation();
+	test_data_buffer();
+	test_processor();
+	test_local_network();
+	test_scene_synchronizer();
+	test_simulation();
 	test_doll_simulation();
 
 	NS::LocalSceneSynchronizer::uninstall_local_scene_sync();


### PR DESCRIPTION
In the previous implementation the `DollController` was processing the exact same timeline executed by the `PlayerController` and that was causing the doll to runs out inputs forcing it to guess them.
The new approach separates the `DollController` and `PlayerController` timelines, while still processing them together: Allowing the `DollController` not to runs out inputs and preventing jittering.