### PR TITLE
Fix unused variable warning with DEB_READ and DEB_WRITE

### DIFF
--- a/data_buffer.cpp
+++ b/data_buffer.cpp
@@ -40,8 +40,8 @@
 #define DEB_ENABLE debug_enabled = was_debug_enabled;
 
 #else
-#define DEB_WRITE(dt, compression, input)
-#define DEB_READ(dt, compression, input)
+#define DEB_WRITE(dt, compression, input) (void)(input);
+#define DEB_READ(dt, compression, input) (void)(input);
 #define DEB_DISABLE
 #define DEB_ENABLE
 #endif


### PR DESCRIPTION
Casting to `void` is a way to "use" a variable without actually doing anything to it, fixing the warning.