### PR TITLE
Fix compile warnings with brace initializers and signed comparisons

### DIFF
--- a/core/core.cpp
+++ b/core/core.cpp
@@ -10,13 +10,13 @@ std::string operator+(const char *p_chr, const std::string &p_str) {
 
 NS_NAMESPACE_BEGIN
 
-const FrameIndex FrameIndex::NONE = { std::numeric_limits<std::uint32_t>::max() };
-const SyncGroupId SyncGroupId::NONE = { std::numeric_limits<std::uint32_t>::max() };
-const SyncGroupId SyncGroupId::GLOBAL = { 0 };
-const VarId VarId::NONE = { std::numeric_limits<uint32_t>::max() };
-const ObjectLocalId ObjectLocalId::NONE = { std::numeric_limits<uint32_t>::max() };
-const ObjectNetId ObjectNetId::NONE = { std::numeric_limits<uint32_t>::max() };
-const ObjectHandle ObjectHandle::NONE = { 0 };
+const FrameIndex FrameIndex::NONE = FrameIndex{{ std::numeric_limits<std::uint32_t>::max() }};
+const SyncGroupId SyncGroupId::NONE = SyncGroupId{{ std::numeric_limits<std::uint32_t>::max() }};
+const SyncGroupId SyncGroupId::GLOBAL = SyncGroupId{{ 0 }};
+const VarId VarId::NONE = VarId{{ std::numeric_limits<uint32_t>::max() }};
+const ObjectLocalId ObjectLocalId::NONE = ObjectLocalId{{ std::numeric_limits<uint32_t>::max() }};
+const ObjectNetId ObjectNetId::NONE = ObjectNetId{{ std::numeric_limits<uint32_t>::max() }};
+const ObjectHandle ObjectHandle::NONE = ObjectHandle{{ 0 }};
 
 static const char *ProcessPhaseName[PROCESS_PHASE_COUNT] = {
 	"EARLY PROCESS",

--- a/core/core.h
+++ b/core/core.h
@@ -92,9 +92,9 @@ struct IdMaker {
 	bool operator>=(const T &p_o) const { return (!operator<(p_o)); }
 	bool operator>(const T &p_o) const { return (!operator<(p_o)) && operator!=(p_o); }
 
-	T operator+(const T &p_o) const { return { id + p_o.id }; }
-	T operator+(int p_id) const { return { id + p_id }; }
-	T operator+(uint32_t p_id) const { return { id + p_id }; }
+	T operator+(const T &p_o) const { return T{{ id + p_o.id }}; }
+	T operator+(int p_id) const { return T{{ id + p_id }}; }
+	T operator+(uint32_t p_id) const { return T{{ id + p_id }}; }
 	T &operator+=(const T &p_o) {
 		id += p_o.id;
 		return *static_cast<T *>(this);
@@ -108,9 +108,9 @@ struct IdMaker {
 		return *static_cast<T *>(this);
 	}
 
-	T operator-(const T &p_o) const { return { id - p_o.id }; }
-	T operator-(int p_id) const { return { id - p_id }; }
-	T operator-(uint32_t p_id) const { return { id - p_id }; }
+	T operator-(const T &p_o) const { return T{{ id - p_o.id }}; }
+	T operator-(int p_id) const { return T{{ id - p_id }}; }
+	T operator-(uint32_t p_id) const { return T{{ id - p_id }}; }
 	T &operator-=(const T &p_o) {
 		id -= p_o.id;
 		return *static_cast<T *>(this);

--- a/core/net_utilities.h
+++ b/core/net_utilities.h
@@ -256,7 +256,7 @@ struct ListenerHandle {
 	}
 
 	static ListenerHandle to_handle(const ChangesListener *p_listener) {
-		return { reinterpret_cast<std::intptr_t>(p_listener) };
+		return ListenerHandle{ reinterpret_cast<std::intptr_t>(p_listener) };
 	}
 };
 inline static const ListenerHandle nulllistenerhandle = { 0 };

--- a/core/object_data_storage.cpp
+++ b/core/object_data_storage.cpp
@@ -183,13 +183,13 @@ ObjectNetId ObjectDataStorage::generate_net_id() const {
 	for (auto od : objects_data_organized_by_netid) {
 		if (!od) {
 			// This position is empty, can be used as NetId.
-			return { i };
+			return ObjectNetId{{ i }};
 		}
 		i++;
 	}
 
 	// Create a new NetId.
-	return { uint32_t(objects_data_organized_by_netid.size()) };
+	return ObjectNetId{{ uint32_t(objects_data_organized_by_netid.size()) }};
 }
 
 bool ObjectDataStorage::is_empty() const {

--- a/core/peer_networked_controller.cpp
+++ b/core/peer_networked_controller.cpp
@@ -299,7 +299,7 @@ bool PeerNetworkedController::__input_data_parse(
 	int ofs = 0;
 
 	ENSURE_V(data_len >= 4, false);
-	const FrameIndex first_input_id = FrameIndex{ decode_uint32(p_data.ptr() + ofs) };
+	const FrameIndex first_input_id = FrameIndex{{ decode_uint32(p_data.ptr() + ofs) }};
 	ofs += 4;
 
 	uint32_t inserted_input_count = 0;
@@ -752,7 +752,7 @@ bool AutonomousServerController::fetch_next_input(double p_delta) {
 
 	if (unlikely(current_input_buffer_id == FrameIndex::NONE)) {
 		// This is the first input.
-		current_input_buffer_id = { 0 };
+		current_input_buffer_id = FrameIndex{{ 0 }};
 	} else {
 		// Just advance from now on.
 		current_input_buffer_id += 1;
@@ -899,7 +899,7 @@ void PlayerController::process(double p_delta) {
 		const bool accept_new_inputs = can_accept_new_inputs();
 
 		if (accept_new_inputs) {
-			current_input_id = FrameIndex{ input_buffers_counter };
+			current_input_id = FrameIndex{{ input_buffers_counter }};
 
 			SceneSynchronizerDebugger::singleton()->print(INFO, "Player process index: " + std::string(current_input_id), "CONTROLLER-" + std::to_string(peer_controller->authority_peer));
 
@@ -1335,7 +1335,7 @@ bool DollController::fetch_next_input(double p_delta) {
 void DollController::process(double p_delta) {
 	const bool is_new_input = fetch_next_input(p_delta);
 
-	if make_likely (current_input_buffer_id > FrameIndex{ 0 }) {
+	if make_likely (current_input_buffer_id > FrameIndex{{ 0 }}) {
 		// This operation is done here, because the doll process on a different
 		// timeline than the one processed by the client.
 		// Whenever it found a server snapshot, it's applied.
@@ -1499,7 +1499,7 @@ void DollController::copy_controlled_objects_snapshot(
 
 	// Find the biggest ID to initialize the snapshot.
 	{
-		ObjectNetId biggest_id = { 0 };
+		ObjectNetId biggest_id = ObjectNetId{{ 0 }};
 		for (ObjectData *object_data : *controlled_objects) {
 			if (object_data->get_net_id() > biggest_id) {
 				biggest_id = object_data->get_net_id();
@@ -1681,7 +1681,7 @@ void DollController::apply_snapshot_instant_input_reconciliation(const Snapshot 
 	if make_likely (frames_input.back().id.id >= std::uint32_t(optimal_queued_inputs)) {
 		last_doll_compared_input = frames_input.back().id - optimal_queued_inputs;
 	} else {
-		last_doll_compared_input = FrameIndex{ 0 };
+		last_doll_compared_input = FrameIndex{{ 0 }};
 	}
 
 	// 3. Once the ideal input to restore is found, it's necessary to find the
@@ -1735,7 +1735,7 @@ void DollController::apply_snapshot_rewinding_input_reconciliation(const Snapsho
 		if make_likely (frames_input.back().id.id >= std::uint32_t(optimal_input_count)) {
 			new_last_doll_compared_input = frames_input.back().id - optimal_input_count;
 		} else {
-			new_last_doll_compared_input = FrameIndex{ 0 };
+			new_last_doll_compared_input = FrameIndex{{ 0 }};
 		}
 
 		// 4. Ensure there is a server snapshot at some point, in between the new
@@ -1779,11 +1779,11 @@ void DollController::apply_snapshot_rewinding_input_reconciliation(const Snapsho
 		// The follow logic make sure that the rewinding is about to happen
 		// doesn't alter this doll timeline: At the end of the rewinding this
 		// doll will be exactly as is right now.
-		const FrameIndex frames_to_travel = { std::uint32_t(p_frame_count_to_rewind + optimal_queued_inputs) };
+		const FrameIndex frames_to_travel = FrameIndex{{ std::uint32_t(p_frame_count_to_rewind + optimal_queued_inputs) }};
 		if make_likely (current_input_buffer_id > frames_to_travel) {
 			last_doll_compared_input = current_input_buffer_id - frames_to_travel;
 		} else {
-			last_doll_compared_input = FrameIndex{ 0 };
+			last_doll_compared_input = FrameIndex{{ 0 }};
 		}
 	} else {
 		last_doll_compared_input = new_last_doll_compared_input;
@@ -1828,7 +1828,7 @@ void DollController::apply_snapshot_rewinding_input_reconciliation(const Snapsho
 
 NoNetController::NoNetController(PeerNetworkedController *p_peer_controller) :
 		Controller(p_peer_controller),
-		frame_id(FrameIndex{ 0 }) {
+		frame_id(FrameIndex{{ 0 }}) {
 }
 
 void NoNetController::process(double p_delta) {

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -332,7 +332,7 @@ public:
 	FrameIndex last_doll_validated_input = FrameIndex::NONE;
 	// The lastest `FrameIndex` on which the server / doll snapshots were compared.
 	FrameIndex last_doll_compared_input = FrameIndex::NONE;
-	FrameIndex queued_frame_index_to_process = FrameIndex{ 0 };
+	FrameIndex queued_frame_index_to_process = FrameIndex{{ 0 }};
 	int queued_instant_to_process = -1;
 
 	// Contains the controlled nodes frames snapshot.

--- a/core/snapshot.cpp
+++ b/core/snapshot.cpp
@@ -63,7 +63,7 @@ bool compare_vars(
 					r_no_rewind_recover->object_vars.data()[p_object_data.get_net_id().id].data()[var_index].copy(s_vars[var_index]);
 					// Sets `input_id` to 0 to signal that this snapshot contains
 					// no-rewind data.
-					r_no_rewind_recover->input_id = NS::FrameIndex{ 0 };
+					r_no_rewind_recover->input_id = NS::FrameIndex{{ 0 }};
 				}
 
 				if (r_differences_info) {
@@ -197,7 +197,7 @@ bool NS::Snapshot::compare(
 	}
 
 	// TODO instead to iterate over all the object_vars, iterate over the simulated. This will make it save a bunch of time.
-	for (ObjectNetId net_object_id = { 0 }; net_object_id < ObjectNetId{ uint32_t(p_snap_A.object_vars.size()) }; net_object_id += 1) {
+	for (ObjectNetId net_object_id = ObjectNetId{{ 0 }}; net_object_id < ObjectNetId{{ uint32_t(p_snap_A.object_vars.size()) }}; net_object_id += 1) {
 		const NS::ObjectData *rew_object_data = scene_synchronizer.get_object_data(net_object_id);
 		if (rew_object_data == nullptr || rew_object_data->realtime_sync_enabled_on_client == false) {
 			continue;
@@ -212,7 +212,7 @@ bool NS::Snapshot::compare(
 		}
 
 		bool are_nodes_different = false;
-		if (net_object_id >= ObjectNetId{ uint32_t(p_snap_B.object_vars.size()) }) {
+		if (net_object_id >= ObjectNetId{{ uint32_t(p_snap_B.object_vars.size()) }}) {
 			if (r_differences_info) {
 				r_differences_info->push_back("Difference detected: The B snapshot doesn't contain this node: " + rew_object_data->object_name);
 			}

--- a/godot4/gd_scene_synchronizer.cpp
+++ b/godot4/gd_scene_synchronizer.cpp
@@ -495,11 +495,11 @@ uint32_t GdSceneSynchronizer::get_node_id(Node *p_node) {
 }
 
 Node *GdSceneSynchronizer::get_node_from_id(uint32_t p_id, bool p_expected) {
-	return SyncClass::from_handle(scene_synchronizer.get_app_object_from_id(NS::ObjectNetId{ p_id }, p_expected));
+	return SyncClass::from_handle(scene_synchronizer.get_app_object_from_id(NS::ObjectNetId{{ p_id }}, p_expected));
 }
 
 const Node *GdSceneSynchronizer::get_node_from_id_const(uint32_t p_id, bool p_expected) const {
-	return SyncClass::from_handle(scene_synchronizer.get_app_object_from_id_const(NS::ObjectNetId{ p_id }, p_expected));
+	return SyncClass::from_handle(scene_synchronizer.get_app_object_from_id_const(NS::ObjectNetId{{ p_id }}, p_expected));
 }
 
 void GdSceneSynchronizer::register_variable(Node *p_node, const StringName &p_variable) {
@@ -658,35 +658,35 @@ uint32_t GdSceneSynchronizer::sync_group_create() {
 }
 
 const NS::SyncGroup *GdSceneSynchronizer::sync_group_get(uint32_t p_group_id) const {
-	return scene_synchronizer.sync_group_get(NS::SyncGroupId{ p_group_id });
+	return scene_synchronizer.sync_group_get(NS::SyncGroupId{{ p_group_id }});
 }
 
 void GdSceneSynchronizer::sync_group_add_node_by_id(uint32_t p_net_id, uint32_t p_group_id, bool p_realtime) {
-	scene_synchronizer.sync_group_add_object(NS::ObjectNetId{ p_net_id }, NS::SyncGroupId{ p_group_id }, p_realtime);
+	scene_synchronizer.sync_group_add_object(NS::ObjectNetId{{ p_net_id }}, NS::SyncGroupId{{ p_group_id }}, p_realtime);
 }
 
 void GdSceneSynchronizer::sync_group_add_node(NS::ObjectData *p_object_data, uint32_t p_group_id, bool p_realtime) {
-	scene_synchronizer.sync_group_add_object(p_object_data, NS::SyncGroupId{ p_group_id }, p_realtime);
+	scene_synchronizer.sync_group_add_object(p_object_data, NS::SyncGroupId{{ p_group_id }}, p_realtime);
 }
 
 void GdSceneSynchronizer::sync_group_remove_node_by_id(uint32_t p_net_id, uint32_t p_group_id) {
-	scene_synchronizer.sync_group_remove_object(NS::ObjectNetId{ p_net_id }, NS::SyncGroupId{ p_group_id });
+	scene_synchronizer.sync_group_remove_object(NS::ObjectNetId{{ p_net_id }}, NS::SyncGroupId{{ p_group_id }});
 }
 
 void GdSceneSynchronizer::sync_group_remove_node(NS::ObjectData *p_object_data, uint32_t p_group_id) {
-	scene_synchronizer.sync_group_remove_object(p_object_data, NS::SyncGroupId{ p_group_id });
+	scene_synchronizer.sync_group_remove_object(p_object_data, NS::SyncGroupId{{ p_group_id }});
 }
 
 void GdSceneSynchronizer::sync_group_replace_nodes(uint32_t p_group_id, LocalVector<NS::SyncGroup::SimulatedObjectInfo> &&p_new_realtime_nodes, LocalVector<NS::SyncGroup::TrickledObjectInfo> &&p_new_trickled_nodes) {
-	scene_synchronizer.sync_group_replace_objects(NS::SyncGroupId{ p_group_id }, std::move(p_new_realtime_nodes), std::move(p_new_trickled_nodes));
+	scene_synchronizer.sync_group_replace_objects(NS::SyncGroupId{{ p_group_id }}, std::move(p_new_realtime_nodes), std::move(p_new_trickled_nodes));
 }
 
 void GdSceneSynchronizer::sync_group_remove_all_nodes(uint32_t p_group_id) {
-	scene_synchronizer.sync_group_remove_all_objects(NS::SyncGroupId{ p_group_id });
+	scene_synchronizer.sync_group_remove_all_objects(NS::SyncGroupId{{ p_group_id }});
 }
 
 void GdSceneSynchronizer::sync_group_move_peer_to(int p_peer_id, uint32_t p_group_id) {
-	scene_synchronizer.sync_group_move_peer_to(p_peer_id, NS::SyncGroupId{ p_group_id });
+	scene_synchronizer.sync_group_move_peer_to(p_peer_id, NS::SyncGroupId{{ p_group_id }});
 }
 
 uint32_t GdSceneSynchronizer::sync_group_get_peer_group(int p_peer_id) const {
@@ -694,31 +694,31 @@ uint32_t GdSceneSynchronizer::sync_group_get_peer_group(int p_peer_id) const {
 }
 
 const std::vector<int> *GdSceneSynchronizer::sync_group_get_listening_peers(uint32_t p_group_id) const {
-	return scene_synchronizer.sync_group_get_listening_peers(NS::SyncGroupId{ p_group_id });
+	return scene_synchronizer.sync_group_get_listening_peers(NS::SyncGroupId{{ p_group_id }});
 }
 
 void GdSceneSynchronizer::sync_group_set_trickled_update_rate_by_id(uint32_t p_net_id, uint32_t p_group_id, real_t p_update_rate) {
-	scene_synchronizer.sync_group_set_trickled_update_rate(NS::ObjectNetId{ p_net_id }, NS::SyncGroupId{ p_group_id }, p_update_rate);
+	scene_synchronizer.sync_group_set_trickled_update_rate(NS::ObjectNetId{{ p_net_id }}, NS::SyncGroupId{{ p_group_id }}, p_update_rate);
 }
 
 void GdSceneSynchronizer::sync_group_set_trickled_update_rate(NS::ObjectData *p_object_data, uint32_t p_group_id, real_t p_update_rate) {
-	scene_synchronizer.sync_group_set_trickled_update_rate(p_object_data->get_local_id(), NS::SyncGroupId{ p_group_id }, p_update_rate);
+	scene_synchronizer.sync_group_set_trickled_update_rate(p_object_data->get_local_id(), NS::SyncGroupId{{ p_group_id }}, p_update_rate);
 }
 
 real_t GdSceneSynchronizer::sync_group_get_trickled_update_rate_by_id(uint32_t p_net_id, uint32_t p_group_id) const {
-	return scene_synchronizer.sync_group_get_trickled_update_rate(NS::ObjectNetId{ p_net_id }, NS::SyncGroupId{ p_group_id });
+	return scene_synchronizer.sync_group_get_trickled_update_rate(NS::ObjectNetId{{ p_net_id }}, NS::SyncGroupId{{ p_group_id }});
 }
 
 real_t GdSceneSynchronizer::sync_group_get_trickled_update_rate(const NS::ObjectData *p_object_data, uint32_t p_group_id) const {
-	return scene_synchronizer.sync_group_get_trickled_update_rate(p_object_data->get_local_id(), NS::SyncGroupId{ p_group_id });
+	return scene_synchronizer.sync_group_get_trickled_update_rate(p_object_data->get_local_id(), NS::SyncGroupId{{ p_group_id }});
 }
 
 void GdSceneSynchronizer::sync_group_set_user_data(uint32_t p_group_id, uint64_t p_user_data) {
-	scene_synchronizer.sync_group_set_user_data(NS::SyncGroupId{ p_group_id }, p_user_data);
+	scene_synchronizer.sync_group_set_user_data(NS::SyncGroupId{{ p_group_id }}, p_user_data);
 }
 
 uint64_t GdSceneSynchronizer::sync_group_get_user_data(uint32_t p_group_id) const {
-	return scene_synchronizer.sync_group_get_user_data(NS::SyncGroupId{ p_group_id });
+	return scene_synchronizer.sync_group_get_user_data(NS::SyncGroupId{{ p_group_id }});
 }
 
 bool GdSceneSynchronizer::is_recovered() const {
@@ -738,7 +738,7 @@ bool GdSceneSynchronizer::is_end_sync() const {
 }
 
 void GdSceneSynchronizer::force_state_notify(uint32_t p_sync_group_id) {
-	scene_synchronizer.force_state_notify(NS::SyncGroupId{ p_sync_group_id });
+	scene_synchronizer.force_state_notify(NS::SyncGroupId{{ p_sync_group_id }});
 }
 
 void GdSceneSynchronizer::force_state_notify_all() {

--- a/godot4/input_network_encoder.cpp
+++ b/godot4/input_network_encoder.cpp
@@ -227,14 +227,14 @@ void InputNetworkEncoder::reset_inputs_to_defaults(LocalVector<Variant> &r_input
 }
 
 bool compare(const Vector2 &p_first, const Vector2 &p_second, float p_tolerance) {
-	return Math::is_equal_approx(p_first.x, p_second.x, p_tolerance) &&
-			Math::is_equal_approx(p_first.y, p_second.y, p_tolerance);
+	return Math::is_equal_approx((float)p_first.x, (float)p_second.x, p_tolerance) &&
+			Math::is_equal_approx((float)p_first.y, (float)p_second.y, p_tolerance);
 }
 
 bool compare(const Vector3 &p_first, const Vector3 &p_second, float p_tolerance) {
-	return Math::is_equal_approx(p_first.x, p_second.x, p_tolerance) &&
-			Math::is_equal_approx(p_first.y, p_second.y, p_tolerance) &&
-			Math::is_equal_approx(p_first.z, p_second.z, p_tolerance);
+	return Math::is_equal_approx((float)p_first.x, (float)p_second.x, p_tolerance) &&
+			Math::is_equal_approx((float)p_first.y, (float)p_second.y, p_tolerance) &&
+			Math::is_equal_approx((float)p_first.z, (float)p_second.z, p_tolerance);
 }
 
 bool compare(const Variant &p_first, const Variant &p_second, float p_tolerance) {
@@ -245,7 +245,7 @@ bool compare(const Variant &p_first, const Variant &p_second, float p_tolerance)
 	// Custom evaluation methods
 	switch (p_first.get_type()) {
 		case Variant::FLOAT: {
-			return Math::is_equal_approx(p_first, p_second, p_tolerance);
+			return Math::is_equal_approx((float)p_first, (float)p_second, p_tolerance);
 		}
 		case Variant::VECTOR2: {
 			return compare(Vector2(p_first), Vector2(p_second), p_tolerance);
@@ -284,7 +284,7 @@ bool compare(const Variant &p_first, const Variant &p_second, float p_tolerance)
 		case Variant::PLANE: {
 			const Plane a(p_first);
 			const Plane b(p_second);
-			if (Math::is_equal_approx(a.d, b.d, p_tolerance)) {
+			if (Math::is_equal_approx((float)a.d, (float)b.d, p_tolerance)) {
 				if (compare(a.normal, b.normal, p_tolerance)) {
 					return true;
 				}
@@ -403,7 +403,7 @@ bool InputNetworkEncoder::are_different(DataBuffer &p_buffer_A, DataBuffer &p_bu
 					are_equals = Math::is_equal_approx(p_buffer_A.read_int(info.compression_level), p_buffer_B.read_int(info.compression_level), info.comparison_floating_point_precision);
 					break;
 				case DataBuffer::DATA_TYPE_REAL:
-					are_equals = Math::is_equal_approx(static_cast<real_t>(p_buffer_A.read_real(info.compression_level)), static_cast<real_t>(p_buffer_B.read_real(info.compression_level)), info.comparison_floating_point_precision);
+					are_equals = Math::is_equal_approx(static_cast<real_t>(p_buffer_A.read_real(info.compression_level)), static_cast<real_t>(p_buffer_B.read_real(info.compression_level)), (real_t)info.comparison_floating_point_precision);
 					break;
 				case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
 					are_equals = Math::is_equal_approx(p_buffer_A.read_positive_unit_real(info.compression_level), p_buffer_B.read_positive_unit_real(info.compression_level), info.comparison_floating_point_precision);

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -445,7 +445,7 @@ void SceneSynchronizerBase::register_variable(ObjectLocalId p_id, const std::str
 		if (valid == false) {
 			SceneSynchronizerDebugger::singleton()->print(ERROR, "The variable `" + p_variable + "` on the node `" + object_data->object_name + "` was not found, make sure the variable exist.", network_interface->get_owner_name());
 		}
-		var_id = VarId{ uint32_t(object_data->vars.size()) };
+		var_id = VarId{{ uint32_t(object_data->vars.size()) }};
 		object_data->vars.push_back(
 				NS::VarDescriptor(
 						var_id,
@@ -459,7 +459,7 @@ void SceneSynchronizerBase::register_variable(ObjectLocalId p_id, const std::str
 	}
 
 #ifdef DEBUG_ENABLED
-	for (VarId v = { 0 }; v < VarId{ uint32_t(object_data->vars.size()) }; v += 1) {
+	for (VarId v = VarId{{ 0 }}; v < VarId{{ uint32_t(object_data->vars.size()) }}; v += 1) {
 		// This can't happen, because the IDs are always consecutive, or NONE.
 		ASSERT_COND(object_data->vars[v.id].id == v);
 	}
@@ -1034,7 +1034,7 @@ void SceneSynchronizerBase::init_synchronizer(bool p_was_generating_ids) {
 
 			// Handle the node ID.
 			if (generate_id) {
-				od->set_net_id({ i });
+				od->set_net_id(ObjectNetId{{ i }});
 			} else {
 				od->set_net_id(ObjectNetId::NONE);
 			}
@@ -1042,7 +1042,7 @@ void SceneSynchronizerBase::init_synchronizer(bool p_was_generating_ids) {
 			// Handle the variables ID.
 			for (uint32_t v = 0; v < od->vars.size(); v += 1) {
 				if (generate_id) {
-					od->vars[v].id = { v };
+					od->vars[v].id = VarId{{ v }};
 				} else {
 					od->vars[v].id = VarId::NONE;
 				}
@@ -1467,8 +1467,8 @@ void SceneSynchronizerBase::process_functions__clear() {
 }
 
 void SceneSynchronizerBase::process_functions__execute() {
-	const std::string info = "delta: " + std::to_string(get_fixed_frame_delta());
-	NS_PROFILE_WITH_INFO(info);
+	const std::string delta_info = "delta: " + std::to_string(get_fixed_frame_delta());
+	NS_PROFILE_WITH_INFO(delta_info);
 
 	if (cached_process_functions_valid == false) {
 		// Clear all the process_functions.
@@ -1515,8 +1515,8 @@ void SceneSynchronizerBase::process_functions__execute() {
 
 	// Pre process phase
 	for (int process_phase = PROCESS_PHASE_EARLY; process_phase < PROCESS_PHASE_COUNT; ++process_phase) {
-		const std::string info = "process phase: " + std::to_string(process_phase);
-		NS_PROFILE_WITH_INFO(info);
+		const std::string phase_info = "process phase: " + std::to_string(process_phase);
+		NS_PROFILE_WITH_INFO(phase_info);
 		cached_process_functions[process_phase].broadcast(get_fixed_frame_delta());
 	}
 }
@@ -1594,7 +1594,7 @@ const NS::PeerData *SceneSynchronizerBase::get_peer_data_for_controller(const Pe
 }
 
 ObjectNetId SceneSynchronizerBase::get_biggest_object_id() const {
-	return objects_data_storage.get_sorted_objects_data().size() == 0 ? ObjectNetId::NONE : ObjectNetId{ uint32_t(objects_data_storage.get_sorted_objects_data().size() - 1) };
+	return objects_data_storage.get_sorted_objects_data().size() == 0 ? ObjectNetId::NONE : ObjectNetId{{ uint32_t(objects_data_storage.get_sorted_objects_data().size() - 1) }};
 }
 
 void SceneSynchronizerBase::reset_controllers() {
@@ -1926,7 +1926,7 @@ void ServerSynchronizer::sync_group_fetch_object_grups(const ObjectData *p_objec
 	r_simulated_groups.clear();
 	r_trickled_groups.clear();
 
-	SyncGroupId id = { 0 };
+	SyncGroupId id = SyncGroupId{{ 0 }};
 	for (const SyncGroup &group : sync_groups) {
 		if (group.get_simulated_sync_objects().find(SyncGroup::SimulatedObjectInfo(const_cast<ObjectData *>(p_object_data))) != -1) {
 			r_simulated_groups.push_back(id);
@@ -2818,7 +2818,7 @@ void ClientSynchronizer::process_received_server_state() {
 				player_controller,
 				inner_player_controller);
 	} else {
-		if (no_rewind_recover.input_id == FrameIndex{ 0 }) {
+		if (no_rewind_recover.input_id == FrameIndex{{ 0 }}) {
 			SceneSynchronizerDebugger::singleton()->notify_event(SceneSynchronizerDebugger::FrameEvent::CLIENT_DESYNC_DETECTED_SOFT);
 
 			// Sync.
@@ -2899,8 +2899,8 @@ bool ClientSynchronizer::__pcr__fetch_recovery_info(
 			const ObjectNetId net_node_id = different_node_data[i];
 			NS::ObjectData *rew_node_data = scene_synchronizer->get_object_data(net_node_id);
 
-			const std::vector<NS::NameAndVar> *server_node_vars = ObjectNetId{ uint32_t(last_received_server_snapshot->object_vars.size()) } <= net_node_id ? nullptr : &(last_received_server_snapshot->object_vars[net_node_id.id]);
-			const std::vector<NS::NameAndVar> *client_node_vars = ObjectNetId{ uint32_t(client_snapshots.front().object_vars.size()) } <= net_node_id ? nullptr : &(client_snapshots.front().object_vars[net_node_id.id]);
+			const std::vector<NS::NameAndVar> *server_node_vars = ObjectNetId{{ uint32_t(last_received_server_snapshot->object_vars.size()) }} <= net_node_id ? nullptr : &(last_received_server_snapshot->object_vars[net_node_id.id]);
+			const std::vector<NS::NameAndVar> *client_node_vars = ObjectNetId{{ uint32_t(client_snapshots.front().object_vars.size()) }} <= net_node_id ? nullptr : &(client_snapshots.front().object_vars[net_node_id.id]);
 
 			const std::size_t count = MAX(server_node_vars ? server_node_vars->size() : 0, client_node_vars ? client_node_vars->size() : 0);
 
@@ -3038,7 +3038,7 @@ void ClientSynchronizer::__pcr__rewind(
 
 void ClientSynchronizer::__pcr__sync__no_rewind(const NS::Snapshot &p_no_rewind_recover) {
 	NS_PROFILE
-	ASSERT_COND_MSG(p_no_rewind_recover.input_id == FrameIndex{ 0 }, "This function is never called unless there is something to recover without rewinding.");
+	ASSERT_COND_MSG(p_no_rewind_recover.input_id == FrameIndex{{ 0 }}, "This function is never called unless there is something to recover without rewinding.");
 
 	// Apply found differences without rewind.
 	std::vector<std::string> applied_data_info;
@@ -3885,7 +3885,7 @@ void ClientSynchronizer::apply_snapshot(
 
 		// NOTE: The vars may not contain ALL the variables: it depends on how
 		//       the snapshot was captured.
-		for (VarId v = { 0 }; v < VarId{ uint32_t(snap_object_vars.size()) }; v += 1) {
+		for (VarId v = VarId{{ 0 }}; v < VarId{{ uint32_t(snap_object_vars.size()) }}; v += 1) {
 			if (snap_object_vars[v.id].name.empty()) {
 				// This variable was not set, skip it.
 				continue;

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -930,7 +930,7 @@ public:
 	}
 
 	static ObjectHandle to_handle(const BaseType *p_app_object) {
-		return { reinterpret_cast<std::intptr_t>(p_app_object) };
+		return ObjectHandle{{ reinterpret_cast<std::intptr_t>(p_app_object) }};
 	}
 
 	static BaseType *from_handle(ObjectHandle p_app_object_handle) {

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -361,7 +361,7 @@ struct TestDollSimulationStorePositions : public TestDollSimulationBase {
 
 	void assert_positions(const std::map<NS::FrameIndex, NS::VarData> &p_player_map, const std::map<NS::FrameIndex, NS::VarData> &p_doll_map, NS::FrameIndex assert_after) {
 		// Find the biggeest FrameInput
-		NS::FrameIndex biggest_frame_index{ 0 };
+		NS::FrameIndex biggest_frame_index = NS::FrameIndex{{ 0 }};
 		for (const auto &[fi, vd] : p_doll_map) {
 			if (fi != NS::FrameIndex::NONE) {
 				if (fi > biggest_frame_index) {
@@ -373,7 +373,7 @@ struct TestDollSimulationStorePositions : public TestDollSimulationBase {
 		ASSERT_COND(assert_after <= biggest_frame_index)
 
 		// Now, iterate over all the frames and make sure the positions are the same
-		for (NS::FrameIndex i{ 0 }; i <= biggest_frame_index; i += 1) {
+		for (NS::FrameIndex i = NS::FrameIndex{{ 0 }}; i <= biggest_frame_index; i += 1) {
 			const NS::VarData *player_position = NS::MapFunc::get_or_null(p_player_map, i);
 			const NS::VarData *doll_position = NS::MapFunc::get_or_null(p_doll_map, i);
 			if (i > assert_after) {
@@ -403,7 +403,7 @@ void test_simulation_reconciliation(float p_frame_confirmation_timespan) {
 	ASSERT_COND(test.peer2_desync_detected.size() == 0);
 
 	// Ensure the positions are all the same.
-	test.assert_positions(NS::FrameIndex{ 0 }, NS::FrameIndex{ 0 });
+	test.assert_positions(NS::FrameIndex{{ 0 }}, NS::FrameIndex{{ 0 }});
 
 	// 2. Introduce a desync manually and test again.
 	test.controlled_1_peer2->set_xy(0, 0); // Modify the doll on peer 1
@@ -427,7 +427,7 @@ void test_simulation_reconciliation(float p_frame_confirmation_timespan) {
 
 		// Make sure the reconciliation was successful.
 		// NOTE: 45 is a margin established basing on the `p_frame_confirmation_timespan`.
-		const NS::FrameIndex ensure_no_desync_after{ 45 };
+		const NS::FrameIndex ensure_no_desync_after = NS::FrameIndex{{ 45 }};
 		test.assert_no_desync(ensure_no_desync_after, ensure_no_desync_after);
 
 		// and despite that the simulations are correct.
@@ -496,14 +496,14 @@ void test_simulation_with_latency() {
 	ASSERT_COND(test.peer2_desync_detected.size() == 0);
 
 	// Ensure the positions are all the same.
-	test.assert_positions(NS::FrameIndex{ 0 }, NS::FrameIndex{ 0 });
+	test.assert_positions(NS::FrameIndex{{ 0 }}, NS::FrameIndex{{ 0 }});
 
 	// 2. Introduce some latency
 	test.network_properties.rtt_seconds = 0.2;
 
 	test.do_test(600);
 
-	NS::FrameIndex assert_after{ 50 };
+	NS::FrameIndex assert_after = NS::FrameIndex{{ 50 }};
 	// Make sure no desync were detected after:
 	test.assert_no_desync(assert_after, assert_after);
 	// Ensure the positions are all the same after:
@@ -513,8 +513,8 @@ void test_simulation_with_latency() {
 	// 3. Remove the latency
 	test.network_properties.rtt_seconds = 0.0;
 
-	const int desync_count_peer_1 = test.peer1_desync_detected.size();
-	const int desync_count_peer_2 = test.peer2_desync_detected.size();
+	const size_t desync_count_peer_1 = test.peer1_desync_detected.size();
+	const size_t desync_count_peer_2 = test.peer2_desync_detected.size();
 
 	test.do_test(200);
 
@@ -642,15 +642,15 @@ void test_simulation_with_wrong_input() {
 	ASSERT_COND(test.peer2_desync_detected.size() == 0);
 
 	// Ensure the positions are all the same.
-	test.assert_positions(NS::FrameIndex{ 0 }, NS::FrameIndex{ 0 });
+	test.assert_positions(NS::FrameIndex{{ 0 }}, NS::FrameIndex{{ 0 }});
 
 	// 2. Now introduce a desync on the server.
 	for (int test_count = 0; test_count < 20; test_count++) {
 		for (int i = 0; i < 3; i++) {
 			const NS::FrameIndex c1_assert_after = server_controller_1->get_current_frame_index() + 70;
 			const NS::FrameIndex c2_assert_after = server_controller_2->get_current_frame_index() + 70;
-			const int c1_desync_vec_size = test.peer1_desync_detected.size();
-			const int c2_desync_vec_size = test.peer2_desync_detected.size();
+			const size_t c1_desync_vec_size = test.peer1_desync_detected.size();
+			const size_t c2_desync_vec_size = test.peer2_desync_detected.size();
 
 			test.controlled_1_serv->modify_input_on_next_frame = true;
 			test.controlled_2_serv->modify_input_on_next_frame = true;

--- a/tests/test_netsync_bit_array.h
+++ b/tests/test_netsync_bit_array.h
@@ -31,7 +31,7 @@
 #ifndef TEST_NETSYNC_BIT_ARRAY_H
 #define TEST_NETSYNC_BIT_ARRAY_H
 
-#include "../bit_array.h"
+#include "../core/bit_array.h"
 
 #include "tests/test_macros.h"
 #include <limits>

--- a/tests/test_scene_synchronizer.cpp
+++ b/tests/test_scene_synchronizer.cpp
@@ -15,9 +15,9 @@
 namespace NS_Test {
 
 void test_ids() {
-	NS::VarId var_id_0 = { 0 };
-	NS::VarId var_id_0_2 = { 0 };
-	NS::VarId var_id_1 = { 1 };
+	NS::VarId var_id_0 = NS::VarId{{ 0 }};
+	NS::VarId var_id_0_2 = NS::VarId{{ 0 }};
+	NS::VarId var_id_1 = NS::VarId{{ 1 }};
 
 	CRASH_COND(var_id_0 != var_id_0_2);
 	CRASH_COND(var_id_0 == var_id_1);
@@ -656,14 +656,14 @@ void test_state_notify() {
 				peer_2_scene.process(delta);
 			}
 
-			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{ 0 });
-			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{ 1 });
+			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{{ 0 }});
+			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{{ 1 }});
 			// NOTE: No need to check the peer_2, because it's not an authoritative controller anyway.
 		} else {
 			// Make sure the controllers have been processed at this point.
-			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex{ 0 });
+			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex{{ 0 }});
 			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex::NONE);
-			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex{ 0 });
+			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex{{ 0 }});
 			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex::NONE);
 
 			// NOTE: No need to check the peer_2, because it's not an authoritative controller anyway.
@@ -711,8 +711,8 @@ void test_processing_with_late_controller_registration() {
 
 	// Make sure the client can process right away as the NetId is networked
 	// already.
-	ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{ 0 });
-	ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{ 1 });
+	ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{{ 0 }});
+	ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{{ 1 }});
 }
 
 void test_snapshot_generation() {
@@ -987,14 +987,14 @@ void test_variable_change_event() {
 				peer_2_scene.process(delta);
 			}
 
-			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{ 0 });
-			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{ 1 });
+			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{{ 0 }});
+			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() == NS::FrameIndex{{ 1 }});
 			// NOTE: No need to check the peer_2, because it's not an authoritative controller anyway.
 		} else {
 			// Make sure the controllers have been processed at this point.
-			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex{ 0 });
+			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex{{ 0 }});
 			ASSERT_COND(server_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex::NONE);
-			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex{ 0 });
+			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex{{ 0 }});
 			ASSERT_COND(peer_1_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index() != NS::FrameIndex::NONE);
 
 			// NOTE: No need to check the peer_2, because it's not an authoritative controller anyway.

--- a/tests/test_simulation.cpp
+++ b/tests/test_simulation.cpp
@@ -235,7 +235,7 @@ struct TestSimulationBase {
 	TSLocalNetworkedController *controlled_obj_p1 = nullptr;
 	NS::PeerNetworkedController *controller_p1 = nullptr;
 
-	NS::FrameIndex process_until_frame = { 300 };
+	NS::FrameIndex process_until_frame = NS::FrameIndex{{ 300 }};
 	int process_until_frame_timeout = 20;
 
 private:
@@ -372,13 +372,13 @@ public:
 /// It manually de-sync the server by teleporting the controller, and then
 /// make sure the client was immediately re-sync with a single rewinding action.
 struct TestSimulationWithRewind : public TestSimulationBase {
-	NS::FrameIndex reset_position_on_frame = { 100 };
+	NS::FrameIndex reset_position_on_frame = NS::FrameIndex{{ 100 }};
 	float notify_state_interval = 0.0;
 
 public:
 	std::vector<NS::FrameIndex> client_rewinded_frames;
 	// The ID of snapshot sent by the server.
-	NS::FrameIndex correction_snapshot_sent = { 0 };
+	NS::FrameIndex correction_snapshot_sent = NS::FrameIndex{{ 0 }};
 
 	TestSimulationWithRewind(float p_notify_state_interval) :
 			notify_state_interval(p_notify_state_interval) {}


### PR DESCRIPTION
This fixes errors like these. Basically it's some weird C++ quirk where we are supposed to use `{{ }}` instead of just `{ }` to avoid a potential ambiguity. This should behave the same as before.

<img width="1300" alt="Screenshot 2024-03-16 at 1 44 37 AM" src="https://github.com/GameNetworking/network_synchronizer/assets/1646875/85f9d715-d515-4206-b65a-c2d1217564cc">

https://stackoverflow.com/questions/31555584/why-is-clang-warning-suggest-braces-around-initialization-of-subobject-wmis

Also included:

- Fix path to `bit_array.h` in tests.
- Fix shadowing variable warnings.
- Fix signed/unsigned warnings, switch a few places to `size_t`.
- Use explicitly named types for brace initializers.

This fixes compiling with warnings, compiling with tests, and compiling for Android.