### PR TITLE
Add PackedVector4Array to `type_to_string`

### DIFF
--- a/core/scene_synchronizer_debugger.cpp
+++ b/core/scene_synchronizer_debugger.cpp
@@ -307,6 +307,8 @@ std::string type_to_string(Variant::Type p_type) {
 			return "PACKED_VECTOR3_ARRAY";
 		case Variant::PACKED_COLOR_ARRAY:
 			return "PACKED_COLOR_ARRAY";
+		case Variant::PACKED_VECTOR4_ARRAY:
+			return "PACKED_VECTOR4_ARRAY";
 		case Variant::VARIANT_MAX:
 			return "VARIANT_MAX";
 	}


### PR DESCRIPTION
This PR fixes compiling with Godot 4.3 beta. @AndreaCatania 

It comes after PackedColorArray so that the cases are in an increasing order.